### PR TITLE
Removes Gemfile.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 /.bundle/
 /lib/bundler/man/
 
-Gemfile.lock
 .ruby-version
 .ruby-gemset
 


### PR DESCRIPTION
Without Gemfile.lock, ensuring that the proper version of gems are used in
production may be difficult.